### PR TITLE
Use new heroku-api instead of old heroku gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
 source 'http://rubygems.org'
 
+gemspec
+
+gem 'activesupport', :require => 'active_support/all'
 gem 'resque', '>= 1.8'
-gem 'heroku', '1.11.0'
+gem 'heroku-api'
 
 group :development do
   gem "rspec", "~> 2.0"
   gem 'rr', '1.0.2'
   gem 'rake'
   gem 'timecop', '0.3.5'
-  end
+end

--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
 Resque Heroku Autoscaler (RHA)
 =======================
 
-A [Resque][rq] plugin. Requires Resque 1.8 and the Heroku gem (only tested with 1.11.0).
+A [Resque][rq] plugin. Requires Resque 1.8 and the Heroku-api gem.
 
 This gem scales your Heroku workers according to the number of pending Resque jobs. The original idea comes from Daniel Huckstep's [blog post on the topic][dh]
+
 
 ##Setup
 
 In order for the scaling to work RHA needs to know your **Heroku app's name, your Heroku user name and your Heroku password**. Per default those are being read from the following environment variables:
 
 - HEROKU_APP
-- HEROKU_USER
-- HEROKU_PASS
+- HEROKU_API_KEY
 
 If you prefer you also can configure RHA using a config block. For example you might put the following into config/initialiazers/resque_heroku_autoscaler_setup.config
 
     require 'resque/plugins/resque_heroku_autoscaler'
 
     Resque::Plugins::HerokuAutoscaler.config do |c|
-      c.heroku_user = 'john doe'
-      c.heroku_pass = ENV['HEROKU_PASSWORD']
       c.heroku_app  = "my_app_#{Rails.env}"
+      c.heroku_api_key = 'abdcef'
     end
 
 

--- a/lib/resque/plugins/heroku_autoscaler/config.rb
+++ b/lib/resque/plugins/heroku_autoscaler/config.rb
@@ -13,14 +13,9 @@ module Resque
 
         @new_worker_count = Proc.new {|pending| pending >0 ? 1 : 0}
 
-        attr_writer :heroku_user
-        def heroku_user
-          @heroku_user || ENV['HEROKU_USER']
-        end
-
-        attr_writer :heroku_pass
-        def heroku_pass
-          @heroku_pass || ENV['HEROKU_PASS']
+        attr_writer :heroku_api_key
+        def heroku_api_key
+          @heroku_api_key || ENV['HEROKU_API_KEY']
         end
 
         attr_writer :heroku_app

--- a/resque-heroku-autoscaler.gemspec
+++ b/resque-heroku-autoscaler.gemspec
@@ -10,12 +10,13 @@ Gem::Specification.new do |s|
   s.authors                  = ["Alexander Murmann"]
   s.email                    = "ajmurmann@gmail.com"
 
-  s.files                    = %w( README.md MIT.LICENSE GEMFILE )
+  s.files                    = %w( README.md MIT.LICENSE Gemfile )
   s.files                    += Dir.glob("lib/**/*")
   s.files                    += Dir.glob("spec/**/*")
 
   s.add_dependency "resque", ">= 1.8"
-  s.add_dependency "heroku"
+  s.add_dependency "heroku-api"
+  s.add_dependency "activesupport"
 
   s.description       = <<desc
 This gem scales your Heroku workers according to the number of pending Resque jobs. You can customize the scaling behavior of your workers, however you like.

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,29 +1,16 @@
 require 'spec_helper'
 
 describe Resque::Plugins::HerokuAutoscaler::Config do
-  describe ".heroku_user" do
-    it "stores the given heroku user name" do
-      subject.heroku_user = "my_user@example.com"
-      subject.heroku_user.should == "my_user@example.com"
+  describe ".heroku_api_key" do
+    it "stores the given heroku api key" do
+      subject.heroku_api_key = "abcd"
+      subject.heroku_api_key.should == "abcd"
     end
 
-    it "defaults to HEROKU_USER environment variable" do
-      subject.heroku_user = nil
-      ENV["HEROKU_USER"]  = "user@example.com"
-      subject.heroku_user.should == "user@example.com"
-    end
-  end
-
-  describe ".heroku_pass" do
-    it "stores the given heroku password" do
-      subject.heroku_pass = "password"
-      subject.heroku_pass.should == "password"
-    end
-
-    it "defaults to HEROKU_PASS environment variable" do
-      subject.heroku_pass = nil
-      ENV["HEROKU_PASS"]  = "123"
-      subject.heroku_pass.should == "123"
+    it "defaults to HEROKU_API_KEY environment variable" do
+      subject.heroku_api_key = nil
+      ENV["HEROKU_API_KEY"]  = "abcdef"
+      subject.heroku_api_key.should == "abcdef"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
 require 'rspec'
-require 'heroku'
+require 'heroku-api'
 require 'resque'
 require 'timecop'
+require 'active_support/all'
 require 'resque/plugins/heroku_autoscaler/config'
 require 'resque/plugins/resque_heroku_autoscaler'
 


### PR DESCRIPTION
Hi, I like the ideas behind this gem, but found that I could not use the super old heroku gem.

This updates all of the heroku interaction to use the newer `heroku-api` gem.

Also, it sets up HEROKU_API_KEY instead of HEROKU_USER and HEROKU_PASS. The new Heroku::API suppors user and password, but I had some issues with it and didn't feel like making sure both worked, so this fork only supports the api key.

I'm not sure if you want to pull in these changes, but I thought I'd pull-request to give you the opportunity, and to help others find this branch should they need it.

I also did not update the version number, although I will in my master branch.
