### PR TITLE
Fix for resque mailer conflict

### DIFF
--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -72,7 +72,7 @@ module Resque
       end
 
       def time_to_scale?
-        (Time.now - Time.parse(Resque.redis.get('last_scaled'))) >=  autoscaler_configconfig.wait_time
+        (Time.now - Time.parse(Resque.redis.get('last_scaled'))) >=  autoscaler_config.wait_time
       end
 
       def log(message)


### PR DESCRIPTION
When you use the autoscaler with resque-mailer, then you get problems due to the config method added on the mailer class ( by extend Resque::Plugins::HerokuAutoscaler) . This config method is assumed(by ActionMailer) to return an object responding to the method inheritable_copy. To avoid this error, i renamed the config method.
