### PR TITLE
Updated the gem to work with the new heroku platform-api gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'activesupport', :require => 'active_support/all'
 gem 'resque', '>= 1.8'
-gem 'heroku-api'
+gem 'platform-api'
 
 group :development do
   gem "rspec", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,84 @@
+PATH
+  remote: .
+  specs:
+    resque-heroku-autoscaler (0.3.1.1)
+      activesupport
+      heroku-api
+      resque (>= 1.8)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activesupport (4.1.4)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    diff-lcs (1.2.5)
+    erubis (2.7.0)
+    excon (0.39.4)
+    heroics (0.0.12)
+      erubis (~> 2.7.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
+      netrc
+    heroku-api (0.3.19)
+      excon (~> 0.38)
+      multi_json (~> 1.8)
+    i18n (0.6.11)
+    json (1.8.1)
+    minitest (5.4.0)
+    moneta (0.8.0)
+    mono_logger (1.1.0)
+    multi_json (1.10.1)
+    netrc (0.7.7)
+    platform-api (0.2.0)
+      heroics (~> 0.0.10)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    rake (10.3.2)
+    redis (3.1.0)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    rr (1.0.2)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.1)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.2)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    thread_safe (0.3.4)
+    tilt (1.4.1)
+    timecop (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  platform-api
+  rake
+  resque (>= 1.8)
+  resque-heroku-autoscaler!
+  rr (= 1.0.2)
+  rspec (~> 2.0)
+  timecop (= 0.3.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     resque-heroku-autoscaler (0.3.1.1)
       activesupport
-      heroku-api
+      platform-api
       resque (>= 1.8)
 
 GEM
@@ -24,9 +24,6 @@ GEM
       moneta
       multi_json (>= 1.9.2)
       netrc
-    heroku-api (0.3.19)
-      excon (~> 0.38)
-      multi_json (~> 1.8)
     i18n (0.6.11)
     json (1.8.1)
     minitest (5.4.0)

--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
-B
 Improvements :
 =======================
 
-##VERSION 0.3
-#sets a maximum number of workers off the config var
+#VERSION 0.3+
+###sets a maximum number of workers off the config var
   -done set the ENV['WORKER_MAX'] or it defaults to 5
-#has an algo for dyno scaler vs amount of workers
+###has an algo for dyno scaler vs amount of workers
   -done
-#logs or saves a ditto
+###logs or saves a ditto
   -logs is done
-#convert between resque workers and heroku worker dynos
+###convert between resque workers and heroku worker dynos
   -done
-#gradual up scaling
+###gradual up scaling
   -done
-#removing the deprecated heroku - api gem
+###removing the deprecated heroku - api gem
   -done
-#sets a minimum off the config var
+###sets a minimum off the config var
   -done set the ENV['WORKER_MIN'] or it defaults to 0
-#gradual down scaling
+###gradual down scaling
   -testing letting heroku handle graceful downgrading
 
 
-VERSION 0.4
-#scale open workers when a slow task has bogged queue - tasks are waiting
+#VERSION 0.4
+###scale open workers when a slow task has bogged queue - tasks are waiting
 
-#turn on / off scaling with an environment var
+###turn on / off scaling with an environment var
   -later
 
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
-Behavior
-
+B
 Improvements :
+=======================
 
-VERSION 0.3
-sets a maximum number of workers off the config var
-  done set the ENV['WORKER_MAX'] or it defaults to 5
-has an algo for dyno scaler vs amount of workers
-  done
-logs or saves a ditto
-  logs is done
-convert between resque workers and heroku worker dynos
-  done
-gradual up scaling
-  done
-removing the deprecated heroku - api gem
-  done
-sets a minimum off the config var
-  done set the ENV['WORKER_MIN'] or it defaults to 0
+##VERSION 0.3
+#sets a maximum number of workers off the config var
+  -done set the ENV['WORKER_MAX'] or it defaults to 5
+#has an algo for dyno scaler vs amount of workers
+  -done
+#logs or saves a ditto
+  -logs is done
+#convert between resque workers and heroku worker dynos
+  -done
+#gradual up scaling
+  -done
+#removing the deprecated heroku - api gem
+  -done
+#sets a minimum off the config var
+  -done set the ENV['WORKER_MIN'] or it defaults to 0
+#gradual down scaling
+  -testing letting heroku handle graceful downgrading
 
 
 VERSION 0.4
-scale open workers when a slow task has bogged queue - tasks are waiting
-gradual down scaling
+#scale open workers when a slow task has bogged queue - tasks are waiting
 
-turn on / off scaling with an environment var
-  later
+#turn on / off scaling with an environment var
+  -later
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+Behavior
+
+Improvements :
+
+VERSION 0.3
+sets a maximum number of workers off the config var
+  done set the ENV['WORKER_MAX'] or it defaults to 5
+has an algo for dyno scaler vs amount of workers
+  done
+logs or saves a ditto
+  logs is done
+convert between resque workers and heroku worker dynos
+  done
+gradual up scaling
+  done
+removing the deprecated heroku - api gem
+  done
+sets a minimum off the config var
+  done set the ENV['WORKER_MIN'] or it defaults to 0
+
+
+VERSION 0.4
+scale open workers when a slow task has bogged queue - tasks are waiting
+gradual down scaling
+
+turn on / off scaling with an environment var
+  later
+
+
+
+
+
 Resque Heroku Autoscaler (RHA)
 =======================
 

--- a/lib/resque/plugins/heroku_autoscaler/config.rb
+++ b/lib/resque/plugins/heroku_autoscaler/config.rb
@@ -11,7 +11,29 @@ module Resque
           @scaling_allowed
         end
 
-        @new_worker_dyno_count = self.scaling_system
+        @new_worker_dyno_count = Proc.new do |data_hsh|
+            pending = data_hsh[:pending].to_i
+            workers = data_hsh[:workers].to_i
+            working = data_hsh[:working].to_i
+            if pending > 0
+              if (workers - 4) < working
+                1
+              else
+                # do nothing
+                0
+              end
+            else
+              if working == 0
+                # kill all the workers
+                nil
+              elsif (workers > working + 8)
+                -1
+              else
+                # do nothing
+                0
+              end
+            end
+          end
 
         attr_writer :heroku_api_key
         def heroku_api_key
@@ -42,7 +64,29 @@ module Resque
 
         def reset
           @scaling_allowed       = true
-          @new_worker_dyno_count = self.scaling_system
+          @new_worker_dyno_count = Proc.new do |data_hsh|
+            pending = data_hsh[:pending].to_i
+            workers = data_hsh[:workers].to_i
+            working = data_hsh[:working].to_i
+            if pending > 0
+              if (workers - 4) < working
+                1
+              else
+                # do nothing
+                0
+              end
+            else
+              if working == 0
+                # kill all the workers
+                nil
+              elsif (workers > working + 8)
+                -1
+              else
+                # do nothing
+                0
+              end
+            end
+          end
         end
 
         def scaling_system

--- a/lib/resque/plugins/heroku_autoscaler/config.rb
+++ b/lib/resque/plugins/heroku_autoscaler/config.rb
@@ -11,7 +11,7 @@ module Resque
           @scaling_allowed
         end
 
-        @new_worker_dyno_count = scaling_system
+        @new_worker_dyno_count = self.scaling_system
 
         attr_writer :heroku_api_key
         def heroku_api_key
@@ -42,10 +42,8 @@ module Resque
 
         def reset
           @scaling_allowed       = true
-          @new_worker_dyno_count = scaling_system
+          @new_worker_dyno_count = self.scaling_system
         end
-
-      private
 
         def scaling_system
           Proc.new do |data_hsh|

--- a/lib/resque/plugins/heroku_autoscaler/config.rb
+++ b/lib/resque/plugins/heroku_autoscaler/config.rb
@@ -4,14 +4,14 @@ module Resque
       module Config
         extend self
 
-        @scaling_disabled = false
+        @scaling_allowed = true
 
-        attr_writer :scaling_disabled
-        def scaling_disabled?
-          @scaling_disabled
+        attr_writer :scaling_allowed
+        def scaling_allowed?
+          @scaling_allowed
         end
 
-        @new_worker_count = Proc.new {|pending| pending >0 ? 1 : 0}
+        @new_worker_dyno_count = scaling_system
 
         attr_writer :heroku_api_key
         def heroku_api_key
@@ -28,17 +28,49 @@ module Resque
           @wait_time || 60
         end
 
-        def new_worker_count(pending=nil, *payload, &calculate_count)
-          if calculate_count
-            @new_worker_count = calculate_count
-          else
-            @new_worker_count.call(pending, *payload)
-          end
+        def max_worker_dynos
+          @max_workers ||= (ENV['WORKER_MAX'] || 5)
+        end
+
+        def min_worker_dynos
+          @min_workers ||= (ENV['WORKER_MIN'] || 0)
+        end
+
+        def new_worker_dyno_count(pending, workers, working)
+          @new_worker_dyno_count.call({ pending: pending, workers: workers, working: working })
         end
 
         def reset
-          @scaling_disabled = false
-          @new_worker_count = Proc.new {|pending| pending >0 ? 1 : 0}
+          @scaling_allowed       = true
+          @new_worker_dyno_count = scaling_system
+        end
+
+      private
+
+        def scaling_system
+          Proc.new do |data_hsh|
+            pending = data_hsh[:pending].to_i
+            workers = data_hsh[:workers].to_i
+            working = data_hsh[:working].to_i
+            if pending > 0
+              if (workers - 4) < working
+                1
+              else
+                # do nothing
+                0
+              end
+            else
+              if working == 0
+                # kill all the workers
+                nil
+              elsif (workers > working + 8)
+                -1
+              else
+                # do nothing
+                0
+              end
+            end
+          end
         end
       end
     end

--- a/lib/resque/plugins/heroku_autoscaler/config.rb
+++ b/lib/resque/plugins/heroku_autoscaler/config.rb
@@ -89,31 +89,31 @@ module Resque
           end
         end
 
-        def scaling_system
-          Proc.new do |data_hsh|
-            pending = data_hsh[:pending].to_i
-            workers = data_hsh[:workers].to_i
-            working = data_hsh[:working].to_i
-            if pending > 0
-              if (workers - 4) < working
-                1
-              else
-                # do nothing
-                0
-              end
-            else
-              if working == 0
-                # kill all the workers
-                nil
-              elsif (workers > working + 8)
-                -1
-              else
-                # do nothing
-                0
-              end
-            end
-          end
-        end
+        # def scaling_system
+        #   Proc.new do |data_hsh|
+        #     pending = data_hsh[:pending].to_i
+        #     workers = data_hsh[:workers].to_i
+        #     working = data_hsh[:working].to_i
+        #     if pending > 0
+        #       if (workers - 4) < working
+        #         1
+        #       else
+        #         # do nothing
+        #         0
+        #       end
+        #     else
+        #       if working == 0
+        #         # kill all the workers
+        #         nil
+        #       elsif (workers > working + 8)
+        #         -1
+        #       else
+        #         # do nothing
+        #         0
+        #       end
+        #     end
+        #   end
+        # end
       end
     end
   end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.1"
+      VERSION = "0.3.1.2"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.2.3"
+      VERSION = "0.3.1.1"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.14"
+      VERSION = "0.3.1.15"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.4"
+      VERSION = "0.3.1.5"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.11"
+      VERSION = "0.3.1.12"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.13"
+      VERSION = "0.3.1.14"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.10"
+      VERSION = "0.3.1.11"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.2"
+      VERSION = "0.3.1.3"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.8"
+      VERSION = "0.3.1.9"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.6"
+      VERSION = "0.3.1.7"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.5"
+      VERSION = "0.3.1.6"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.12"
+      VERSION = "0.3.1.13"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.9"
+      VERSION = "0.3.1.10"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.3"
+      VERSION = "0.3.1.4"
     end
   end
 end

--- a/lib/resque/plugins/heroku_autoscaler/version.rb
+++ b/lib/resque/plugins/heroku_autoscaler/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module HerokuAutoscaler
-      VERSION = "0.3.1.7"
+      VERSION = "0.3.1.8"
     end
   end
 end

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -38,6 +38,7 @@ module Resque
 
 				cwd = current_worker_dynos if cwd.nil?
 				log("\nScaling Resque Worker - new_dyno_count = |#{new_dyno_count}| current dynos = #{cwd}")
+
 				if new_dyno_count.nil?
 					send_heroku_kill_all_to_min_workers
 				elsif new_dyno_count == 1
@@ -87,6 +88,7 @@ module Resque
 					if time_to_scale?
 						pending = Resque.info[:pending] + post_adjust
 						working = Resque.info[:working] + post_adjust
+						log("\nScaling Resque Worker - p:#{pending} wkrs:#{ Resque.info[:workers]}, wing:#{working}")
 						new_dyno_count = config.new_worker_dyno_count(pending, Resque.info[:workers], working)
 						scale(new_dyno_count)
 					end

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -13,6 +13,7 @@ module Resque
 			end
 
 			def after_enqueue_scale_workers_up(*args)
+				log("\nScaling Resque Worker - after_enqueue_scale_workers_up")
 				if current_worker_dynos == 0
 					scale(1, 0)
 				else
@@ -21,10 +22,12 @@ module Resque
 			end
 
 			def after_perform_scale_workers(*args)
+				log("\nScaling Resque Worker - after_perform_scale_workers")
 				calculate_and_set_worker_dynos
 			end
 
 			def on_failure_scale_workers(*args)
+				log("\nScaling Resque Worker - on_failure_scale_workers")
 				calculate_and_set_worker_dynos
 			end
 

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -29,11 +29,28 @@ module Resque
 
 		private
 
-			def scale(new_dyno_count, cwd=nil)
-				return nil if new_dyno_count == 0
+			def calculate_and_set_worker_dynos(post_adjust=0)
+				if config.scaling_allowed?
+					pending = Resque.info[:pending]
+					if (current_worker_dynos == 0) && (pending > 0)
+						scale(1, 0)
+					else
+						wait_for_task_or_scale
+						if time_to_scale?
+							working = Resque.info[:working] + post_adjust
+							log("\nScaling Resque Worker - p:#{pending} wkrs:#{ Resque.info[:workers]}, wing:#{working}")
+							new_dyno_count = config.new_worker_dyno_count(pending, Resque.info[:workers], working)
+							scale(new_dyno_count)
+						end
+					end
+				end
+			end
 
+			def scale(new_dyno_count, cwd=nil)
 				cwd = current_worker_dynos if cwd.nil?
 				log("\nScaling Resque Worker - new_dyno_count = |#{new_dyno_count}| current dynos = #{cwd}")
+
+				return nil if new_dyno_count == 0
 
 				if new_dyno_count.nil?
 					send_heroku_kill_all_to_min_workers
@@ -78,25 +95,9 @@ module Resque
 				@heroku_api ||= PlatformAPI.connect_oauth(config.heroku_api_key)
 			end
 
-			def calculate_and_set_worker_dynos(post_adjust=0)
-				if config.scaling_allowed?
-					pending = Resque.info[:pending]
-					if (current_worker_dynos == 0) && (pending > 0)
-						scale(1, 0)
-					else
-						wait_for_task_or_scale
-						if time_to_scale?
-							working = Resque.info[:working] + post_adjust
-							log("\nScaling Resque Worker - p:#{pending} wkrs:#{ Resque.info[:workers]}, wing:#{working}")
-							new_dyno_count = config.new_worker_dyno_count(pending, Resque.info[:workers], working)
-							scale(new_dyno_count)
-						end
-					end
-				end
-			end
 
 			def wait_for_task_or_scale
-				until Resque.info[:pending] > 0 || time_to_scale?
+				if Resque.info[:pending] == 0 || !time_to_scale?
 					Kernel.sleep(0.5)
 				end
 			end

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -31,14 +31,14 @@ module Resque
 
 			def calculate_and_set_worker_dynos(post_adjust=0)
 				if config.scaling_allowed?
+					log("\nScaling Resque Worker - p:#{pending} wkrs:#{ Resque.info[:workers]}, wing:#{working}")
 					pending = Resque.info[:pending]
 					if (current_worker_dynos == 0) && (pending > 0)
 						scale(1, 0)
 					else
-						wait_for_task_or_scale
-						if time_to_scale?
+						#wait_for_task_or_scale
+						if true #time_to_scale?
 							working = Resque.info[:working] + post_adjust
-							log("\nScaling Resque Worker - p:#{pending} wkrs:#{ Resque.info[:workers]}, wing:#{working}")
 							new_dyno_count = config.new_worker_dyno_count(pending, Resque.info[:workers], working)
 							scale(new_dyno_count)
 						end

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -31,14 +31,14 @@ module Resque
 
 			def calculate_and_set_worker_dynos(post_adjust=0)
 				if config.scaling_allowed?
-					log("\nScaling Resque Worker - p:#{pending} wkrs:#{ Resque.info[:workers]}, wing:#{working}")
 					pending = Resque.info[:pending]
+					working = Resque.info[:working]  + post_adjust
+					log("\nScaling Resque Worker - p:#{pending} wkrs:#{ Resque.info[:workers]}, wing:#{working}")
 					if (current_worker_dynos == 0) && (pending > 0)
 						scale(1, 0)
 					else
 						#wait_for_task_or_scale
 						if true #time_to_scale?
-							working = Resque.info[:working] + post_adjust
 							new_dyno_count = config.new_worker_dyno_count(pending, Resque.info[:workers], working)
 							scale(new_dyno_count)
 						end

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -86,7 +86,8 @@ module Resque
 					wait_for_task_or_scale
 					if time_to_scale?
 						pending = Resque.info[:pending] + post_adjust
-						new_dyno_count = config.new_worker_dyno_count(pending,Resque.info[:workers],Resque.info[:working])
+						working = Resque.info[:working] + post_adjust
+						new_dyno_count = config.new_worker_dyno_count(pending, Resque.info[:workers], working)
 						scale(new_dyno_count)
 					end
 				end

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -82,7 +82,7 @@ module Resque
 			end
 
 			def send_heroku_change_workers num
-				if num <= config.max_worker_dynos
+				if num <= config.max_worker_dynos.to_i
 					log("\nScaling Resque Worker- send_heroku_change_workers #{num}")
 					heroku_api.formation.update(config.heroku_app, 'worker', {'quantity' => num })
 				else

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -64,7 +64,7 @@ module Resque
 				# wary = ary.select { |pro| pro["type"] == "worker" }
 				# qary = wary.map {|a| a["quantity"] }
 				# qary.sum
-				q = heroku.dyno.list(config.heroku_app)
+				q = heroku_api.dyno.list(config.heroku_app)
 				q.sum do |d|
 					if d["type"] == "worker" && d["state"] == "up"
 					 	1

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -60,6 +60,7 @@ module Resque
 
 			def send_heroku_change_workers num
 				if num <= config.max_worker_dynos
+					log("\nScaling Resque Worker- send_heroku_change_workers #{num}")
 					heroku_api.formation.update(config.heroku_app, 'worker', {'quantity' => num })
 				else
 					log("\nScaling Resque Worker- max worker limit hit #{num}")

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -23,12 +23,12 @@ module Resque
 
 			def after_perform_scale_workers(*args)
 				log("\nScaling Resque Worker - after_perform_scale_workers")
-				calculate_and_set_worker_dynos
+				calculate_and_set_worker_dynos(-1)
 			end
 
 			def on_failure_scale_workers(*args)
 				log("\nScaling Resque Worker - on_failure_scale_workers")
-				calculate_and_set_worker_dynos
+				calculate_and_set_worker_dynos(-1)
 			end
 
 		private
@@ -81,11 +81,12 @@ module Resque
 				@heroku_api ||= PlatformAPI.connect_oauth(config.heroku_api_key)
 			end
 
-			def calculate_and_set_worker_dynos
+			def calculate_and_set_worker_dynos(post_adjust=0)
 				if config.scaling_allowed?
 					wait_for_task_or_scale
 					if time_to_scale?
-						new_dyno_count = config.new_worker_dyno_count(Resque.info[:pending],Resque.info[:workers],Resque.info[:working])
+						pending = Resque.info[:pending] + post_adjust
+						new_dyno_count = config.new_worker_dyno_count(pending,Resque.info[:workers],Resque.info[:working])
 						scale(new_dyno_count)
 					end
 				end

--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -1,83 +1,114 @@
-require 'heroku-api'
+require 'platform-api'
 require 'resque/plugins/heroku_autoscaler/config'
 
 module Resque
-  module Plugins
-    module HerokuAutoscaler
-      def config
-        Resque::Plugins::HerokuAutoscaler::Config
-      end
+	module Plugins
+		module HerokuAutoscaler
+			def config
+				Resque::Plugins::HerokuAutoscaler::Config
+			end
 
-      def after_enqueue_scale_workers_up(*args)
-        if !config.scaling_disabled? && \
-          Resque.info[:workers] == 0 && \
-          config.new_worker_count(Resque.info[:pending]) >= 1
+			def self.config
+				yield Resque::Plugins::HerokuAutoscaler::Config
+			end
 
-          set_workers(1)
-          Resque.redis.set('last_scaled', Time.now)
-        end
-      end
+			def after_enqueue_scale_workers_up(*args)
+				if current_worker_dynos == 0
+					scale(1, 0)
+				else
+					calculate_and_set_worker_dynos
+				end
+			end
 
-      def after_perform_scale_workers(*args)
-        calculate_and_set_workers
-      end
+			def after_perform_scale_workers(*args)
+				calculate_and_set_worker_dynos
+			end
 
-      def on_failure_scale_workers(*args)
-        calculate_and_set_workers
-      end
+			def on_failure_scale_workers(*args)
+				calculate_and_set_worker_dynos
+			end
 
-      def set_workers(number_of_workers)
-        if number_of_workers != current_workers
-          heroku_api.post_ps_scale(config.heroku_app, 'worker', number_of_workers)
-        end
-      end
+		private
 
-      def current_workers
-        heroku_api.get_ps(config.heroku_app).body.count {|p| p['process'].match(/worker\.\d+/) }
-      end
+			def scale(new_dyno_count, cwd=nil)
+				return nil if new_dyno_count == 0
 
-      def heroku_api
-        @heroku_api ||= ::Heroku::API.new(api_key: config.heroku_api_key)
-      end
+				cwd = current_worker_dynos if cwd.nil?
+				log("\nScaling Resque Worker - new_dyno_count = |#{new_dyno_count}| current dynos = #{cwd}")
+				if new_dyno_count.nil?
+					send_heroku_kill_all_to_min_workers
+				elsif new_dyno_count == 1
+					send_heroku_change_workers (cwd + 1)
+				elsif new_dyno_count == -1
+					# cant scale down yet
+					# if i could find out what worker the Resque job is on
+					# i could then find out what workers dont have jobs and kill those
+				end
+				Resque.redis.set('last_scaled', Time.now)
+			end
 
-      def self.config
-        yield Resque::Plugins::HerokuAutoscaler::Config
-      end
+			def send_heroku_kill_all_to_min_workers
+				heroku_api.formation.update(config.heroku_app, 'worker', {'quantity' => config.min_worker_dynos })
+			end
 
-      def calculate_and_set_workers
-        unless config.scaling_disabled?
-          wait_for_task_or_scale
-          if time_to_scale?
-            scale
-          end
-        end
-      end
+			def send_heroku_change_workers num
+				if num <= config.max_worker_dynos
+					heroku_api.formation.update(config.heroku_app, 'worker', {'quantity' => num })
+				else
+					log("\nScaling Resque Worker- max worker limit hit #{num}")
+				end
+			end
 
-      private
+			def current_worker_dynos
+				# ary  = heroku.formation.list(config.heroku_app)
+				# wary = ary.select { |pro| pro["type"] == "worker" }
+				# qary = wary.map {|a| a["quantity"] }
+				# qary.sum
+				q = heroku.dyno.list(config.heroku_app)
+				q.sum do |d|
+					if d["type"] == "worker" && d["state"] == "up"
+					 	1
+					else
+						0
+					end
+				end
+			end
 
-      def scale
-        new_count = config.new_worker_count(Resque.info[:pending])
-        set_workers(new_count) if new_count == 0 || new_count > current_workers
-        Resque.redis.set('last_scaled', Time.now)
-      end
+			def heroku_api
+				@heroku_api ||= PlatformAPI.connect_oauth(config.heroku_api_key)
+			end
 
-      def wait_for_task_or_scale
-        until Resque.info[:pending] > 0 || time_to_scale?
-          Kernel.sleep(0.5)
-        end
-      end
+			def calculate_and_set_worker_dynos
+				if config.scaling_allowed?
+					wait_for_task_or_scale
+					if time_to_scale?
+						new_dyno_count = config.new_worker_dyno_count(Resque.info[:pending],Resque.info[:workers],Resque.info[:working])
+						scale(new_dyno_count)
+					end
+				end
+			end
 
-      def time_to_scale?
-        (Time.now - Time.parse(Resque.redis.get('last_scaled'))) >=  config.wait_time
-      end
+			def wait_for_task_or_scale
+				until Resque.info[:pending] > 0 || time_to_scale?
+					Kernel.sleep(0.5)
+				end
+			end
 
-      def log(message)
-        if defined?(Rails)
-          Rails.logger.info(message)
-        else
-          puts message
-        end
-      end
-    end
-  end
+			def time_to_scale?
+				if Resque.redis.get('last_scaled').nil?
+					Resque.redis.set('last_scaled', Time.now)
+					return true
+				end
+				(Time.now - Time.parse(Resque.redis.get('last_scaled'))) >=  config.wait_time
+			end
+
+			def log(message)
+				if defined?(Rails)
+					Rails.logger.info(message)
+				else
+					puts message
+				end
+			end
+		end
+	end
 end

--- a/resque-heroku-autoscaler.gemspec
+++ b/resque-heroku-autoscaler.gemspec
@@ -6,16 +6,16 @@ Gem::Specification.new do |s|
   s.date                     = Time.now.strftime('%Y-%m-%d')
   s.version                  = Resque::Plugins::HerokuAutoscaler::VERSION
   s.summary                  = "Resque plugin to autoscale your workers on Heroku"
-  s.homepage                 = "https://github.com/ajmurmann/resque-heroku-autoscaler"
-  s.authors                  = ["Alexander Murmann"]
-  s.email                    = "ajmurmann@gmail.com"
+  s.homepage                 = "https://github.com/joncode/resque-heroku-autoscaler"
+  s.authors                  = ["Jon Gutwillig"]
+  s.email                    = "jon.gutwillig@itson.me"
 
   s.files                    = %w( README.md MIT.LICENSE Gemfile )
   s.files                    += Dir.glob("lib/**/*")
   s.files                    += Dir.glob("spec/**/*")
 
   s.add_dependency "resque", ">= 1.8"
-  s.add_dependency "heroku-api"
+  s.add_dependency "platform-api"
   s.add_dependency "activesupport"
 
   s.description       = <<desc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'rspec'
-require 'heroku-api'
+require 'platform-api'
 require 'resque'
 require 'timecop'
 require 'active_support/all'


### PR DESCRIPTION
Most of this is custom stuff for my ITs On Me application.  Not sure if you would find it useful.
However, the code for using the new heroku platform-api gem is in there.  The heroku-api gem is deprecated.
Fixed a bug where redis['last_scaled'] was nil on my platform 

Also, this gem now spins up to a max and down to a min that can be set in the env vars.

There is some wacky code to decide when to add dyno and when not to , kinda weird , its very custom to our platform .. 

Thanks for your gem , hope this can contribute some ,  I plan on iterating on this a bit to optimize it and fix whatever bugs arise.

Jon 
