### PR TITLE
Handle when heroku is down

### DIFF
--- a/lib/resque/plugins/resque_heroku_autoscaler.rb
+++ b/lib/resque/plugins/resque_heroku_autoscaler.rb
@@ -30,10 +30,14 @@ module Resque
         if number_of_workers != current_workers
           heroku_api.post_ps_scale(config.heroku_app, 'worker', number_of_workers)
         end
+      rescue *config.api_exceptions => e
+        config.exception_handler e
       end
 
       def current_workers
         heroku_api.get_ps(config.heroku_app).body.count {|p| p['process'].match(/worker\.\d+/) }
+      rescue *config.api_exceptions => e
+        config.exception_handler e
       end
 
       def heroku_api

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -29,11 +29,11 @@ describe Resque::Plugins::HerokuAutoscaler::Config do
 
   describe ".scaling_disabled?" do
 
-    it{ Resque::Plugins::HerokuAutoscaler::Config.scaling_disabled?.should be_false}
+    it{ Resque::Plugins::HerokuAutoscaler::Config.scaling_disabled?.should be false }
 
     it "sets scaling to disabled" do
       subject.scaling_disabled = true
-      subject.scaling_disabled?.should be_true
+      subject.scaling_disabled?.should be true
     end
   end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -86,4 +86,38 @@ describe Resque::Plugins::HerokuAutoscaler::Config do
       end
     end
   end
+
+  describe '.exception_handler' do
+    it 'has a default that does not raise' do
+      e = Exception.new('OMG')
+      subject.exception_handler(e)
+    end
+
+    it "can store a new block as a Proc" do
+      @called = false
+
+      subject.exception_handler do |e|
+        @called = true
+      end
+
+      subject.exception_handler(nil)
+      expect(@called).to be true
+    end
+
+  end
+
+
+  describe '.api_exceptions' do
+    it 'has a sane default' do
+      expected = [Excon::Errors::Error, Heroku::API::Errors::ErrorWithResponse]
+      expect(Resque::Plugins::HerokuAutoscaler::Config.api_exceptions).to eq expected
+    end
+
+    it "can be set" do
+      subject.api_exceptions = [Heroku::API::Errors::RateLimitExceeded]
+      expect(subject.api_exceptions).to eq [Heroku::API::Errors::RateLimitExceeded]
+      # Reset to default for other tests to function properly
+      subject.api_exceptions = [Excon::Errors::Error, Heroku::API::Errors::ErrorWithResponse]
+    end
+  end
 end


### PR DESCRIPTION
I had a couple of requests 500 when Heroku recently had some API unavailability. Because of this, I want resque-heroku-autoscaler to ignore exceptions when attempting to connect to the API, and instead just try to autoscale next time. My solution here was pretty much cargo-culted from https://github.com/JustinLove/autoscaler/issues/30.
